### PR TITLE
Add AFA Project Officer open position

### DIFF
--- a/pages/opportunities.html
+++ b/pages/opportunities.html
@@ -114,6 +114,24 @@
                         <span class="opp-card__hint"><i class="fas fa-envelope"></i> Subject line: position you are applying for</span>
                     </div>
                 </div>
+                <div class="opportunity-card opportunity-card--featured is-live">
+                    <div class="opp-status opp-status--live"><i class="fas fa-circle"></i> Now Hiring</div>
+                    <h3>AFA Project Officer</h3>
+                    <p class="opp-card__lead">The DAF CGOC hosts an annual CGO Networking event and Social at the September AFA Air, Space &amp; Cyber Conference in DC &mdash; a great opportunity to work directly with the council and connect CGOs globally.</p>
+                    <ul class="opp-card__list">
+                        <li><i class="fas fa-check"></i> Be physically present at AFA to facilitate the Networking and Social events.</li>
+                        <li><i class="fas fa-check"></i> Starting in July, attend ~30-minute bi-weekly DAF CGOC planning syncs.</li>
+                        <li><i class="fas fa-check"></i> Draft the Networking event agenda.</li>
+                        <li><i class="fas fa-check"></i> Assist with on-the-ground setup &mdash; hand out DAF CGOC brochures and event flyers for both the Networking and Social events.</li>
+                        <li><i class="fas fa-check"></i> Oversee DAF CGOC swag sales.</li>
+                        <li><i class="fas fa-check"></i> Identify and reserve the location for the Social event.</li>
+                    </ul>
+                    <div class="opp-card__actions">
+                        <a href="mailto:nationalcgoc@gmail.com?subject=Application%20%E2%80%93%20AFA%20Project%20Officer" class="btn-gold">Apply Now</a>
+                        <a href="https://www.afa.org/air-space-cyber-conference/" target="_blank" class="btn-outline-gold">Learn More About AFA</a>
+                        <span class="opp-card__hint"><i class="fas fa-envelope"></i> Subject line: position you are applying for</span>
+                    </div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
Adds the AFA Project Officer card to the Open Positions section of the Opportunities page, using the finalized responsibilities from the AFCGOC task note.

**Position:** AFA Project Officer
**Context:** DAF CGOC's annual CGO Networking event + Social at the September AFA Air, Space & Cyber Conference (DC).

Responsibilities on the card:
- Be physically present at AFA to facilitate the Networking and Social events
- Starting in July, attend ~30-min bi-weekly DAF CGOC planning syncs
- Draft the Networking event agenda
- Assist with on-the-ground setup (brochures/flyers)
- Oversee DAF CGOC swag sales
- Identify and reserve the Social event location

"Learn More About AFA" links to afa.org/air-space-cyber-conference/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)