### PR TITLE
Add Firebase analytics dual-tagging + section engagement events (all pages)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 	
 	<!--- basic page needs
@@ -633,6 +634,7 @@
    ================================================== -->
 	<script src="js/main.js"></script>
 
+    <script src="js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,36 @@
+/* ============================================================
+   DAF CGOC — shared analytics events (loaded on every page)
+   Sends PII-free engagement events via the gtag defined in each
+   page's <head>. File downloads, outbound clicks, and 90% scroll
+   are covered by GA4 Enhanced Measurement (property setting) —
+   this file only adds what GA can't see on its own: which page
+   sections people actually reach and read.
+   ============================================================ */
+(function () {
+  "use strict";
+
+  function track(name, params) {
+    if (typeof window.gtag === "function") window.gtag("event", name, params || {});
+  }
+
+  /* Section engagement: fire once per section when half the section is
+     visible, or (for sections taller than the screen) when the section
+     fills half the viewport. */
+  if ("IntersectionObserver" in window) {
+    var seen = {};
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        var id = entry.target.id;
+        if (!entry.isIntersecting || seen[id]) return;
+        var viewportCovered = entry.intersectionRect.height / (window.innerHeight || 1);
+        if (entry.intersectionRatio < 0.5 && viewportCovered < 0.5) return;
+        seen[id] = true;
+        track("section_view", { section_id: id });
+        io.unobserve(entry.target);
+      });
+    }, { threshold: [0.15, 0.5] });
+    document.querySelectorAll("section[id], div.section[id]").forEach(function (s) {
+      io.observe(s);
+    });
+  }
+})();

--- a/pages/award-winners.html
+++ b/pages/award-winners.html
@@ -11,6 +11,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
     
     <!--- basic page needs
@@ -356,6 +357,7 @@
     ================================================== --> 
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/councils.html
+++ b/pages/councils.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <meta charset="utf-8">
@@ -177,6 +178,7 @@
     <script src="../js/main.js"></script>
     <script src="../js/map-functionality.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/defo.html
+++ b/pages/defo.html
@@ -11,6 +11,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <!--- basic page needs
@@ -160,6 +161,7 @@
     ================================================== -->
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/donate.html
+++ b/pages/donate.html
@@ -11,6 +11,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <!--- basic page needs
@@ -167,6 +168,7 @@
 
 
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/leadership.html
+++ b/pages/leadership.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <meta charset="utf-8">
@@ -483,6 +484,7 @@
 
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/moaa.html
+++ b/pages/moaa.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <meta charset="utf-8">
@@ -154,6 +155,7 @@
 
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/opportunities.html
+++ b/pages/opportunities.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <meta charset="utf-8">
@@ -302,6 +303,7 @@
 
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <!--- basic page needs
@@ -255,6 +256,7 @@
     ================================================== -->
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/store.html
+++ b/pages/store.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <!--- basic page needs
@@ -148,6 +149,7 @@
     ================================================== -->
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>

--- a/pages/usaa.html
+++ b/pages/usaa.html
@@ -9,6 +9,7 @@
         gtag('js', new Date());
 
         gtag('config', 'G-74QCBZFVWH');
+        gtag('config', 'G-WT36BHRC7X');
     </script>
 
     <meta charset="utf-8">
@@ -143,6 +144,7 @@
 
     <script src="../js/main.js"></script>
 
+    <script src="../js/analytics.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
Adds the deep-analytics layer requested for the whole dafcgoc site.

## What
- **All 11 pages** now send hits to BOTH GA properties: the existing sitewide `G-74QCBZFVWH` and the new Firebase "analytics" web app property `G-WT36BHRC7X` — so the Firebase console dashboards light up without losing continuity in the current GA property. One gtag.js loader, two config lines.
- **New shared `js/analytics.js`**: fires a PII-free `section_view` event the first time a visitor actually reaches each page section (handles sections taller than the viewport).

## What is NOT in code (GA property settings, no deploy needed)
File downloads (PDFs etc.), outbound clicks, and 90% scroll depth are tracked by GA4 **Enhanced Measurement** — confirm the toggles are on for both web streams (GA Admin → Data streams → Enhanced measurement). This restores the old file-download tracking.

## Verification
Served locally and driven with Chrome DevTools: both measurement IDs config'd, `analytics.js` loads on the homepage, `section_view` fired for every observable section while scrolling. Diff is 2 lines per HTML page + the new shared script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)