### PR TITLE
Flip Penpal card to Active Initiative, link to penpal.dafcgoc.org

### DIFF
--- a/pages/opportunities.html
+++ b/pages/opportunities.html
@@ -252,12 +252,13 @@
                     </div>
                 </div>
 
-                <div class="opportunity-card is-coming-soon">
-                    <div class="opp-status opp-status--soon"><i class="fas fa-clock"></i> Coming Soon</div>
+                <div class="opportunity-card is-live">
+                    <div class="opp-status opp-status--live"><i class="fas fa-circle"></i> Active Initiative</div>
                     <h3>Penpal Program</h3>
-                    <p>A DAF CGOC initiative in development. Connecting cadets and new Lieutenants with established base CGOC leadership across the total force. AFROTC and USAFA cadre can submit cadets directly.</p>
+                    <p>The DAF CGOC Mentorship Program pairs cadets and new Lieutenants with an experienced CGO at their first duty station. Guidance, not oversight. AFROTC and USAFA cadre can refer cadets directly, and sign-up takes about two minutes.</p>
                     <div class="opp-card__actions">
-                        <a href="mailto:penpal@dafcgoc.org?subject=Penpal%20%E2%80%93%20Interest" class="btn-outline-gold">I Want to Learn More</a>
+                        <a href="https://penpal.dafcgoc.org" class="btn-gold">Visit the Mentorship Site</a>
+                        <a href="https://penpal.dafcgoc.org/#intake" class="btn-outline-gold">Sign Up Now</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The Penpal Program launched today at https://penpal.dafcgoc.org. This flips the Opportunities-tab card from Coming Soon (mailto) to Active Initiative with buttons to the live site and its sign-up form, matching the FTOC live-card pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)